### PR TITLE
Added broker-status function and optimzed create-instance script

### DIFF
--- a/src/utils/AWS/Security-Groups/createBrokerSG.ts
+++ b/src/utils/AWS/Security-Groups/createBrokerSG.ts
@@ -41,9 +41,8 @@ const ipPermissions = [
 
 async function getSecurityGroupId(
   groupName: string,
-  description: string,
   vpcId: string | undefined,
-  client: EC2Client,
+  client: EC2Client
 ) {
   // First, check if the security group exists in the specified VPC.
   const describeParams = {
@@ -71,7 +70,7 @@ async function getSecurityGroupId(
 
 async function authorizeSecurityGroupIngress(
   client: EC2Client,
-  securityGroupId: string | undefined,
+  securityGroupId: string | undefined
 ) {
   if (!securityGroupId) {
     throw new Error("No security group ID found");
@@ -95,7 +94,7 @@ async function authorizeSecurityGroupIngress(
 }
 
 export async function getDefaultVpcId(
-  client: EC2Client,
+  client: EC2Client
 ): Promise<string | undefined> {
   const command = new DescribeVpcsCommand({
     Filters: [
@@ -116,16 +115,15 @@ export async function getDefaultVpcId(
 
 export async function createSecurityGroup(
   client: EC2Client,
-  vpcId: string | undefined,
+  vpcId: string | undefined
 ): Promise<string | undefined> {
   const securityGroupName = "BrokerSecurityGroup";
   const description = "Security group for RabbitMQ EC2 instance";
 
   const securityGroupId = await getSecurityGroupId(
     securityGroupName,
-    description,
     vpcId,
-    client,
+    client
   );
 
   if (securityGroupId) {

--- a/src/utils/RabbitMQ/serverStatus.ts
+++ b/src/utils/RabbitMQ/serverStatus.ts
@@ -1,0 +1,74 @@
+import axios, { Axios } from "axios";
+import {
+  waitUntilInstanceRunning,
+  EC2Client,
+  DescribeInstancesCommand,
+} from "@aws-sdk/client-ec2";
+export async function pollRabbitMQServerStatus(
+  instanceId: string | undefined,
+  username: string,
+  password: string,
+  region: string
+) {
+  const ec2Client = new EC2Client({ region });
+  await waitUntilInstanceRunning(
+    { client: ec2Client, maxWaitTime: 3000 },
+    { InstanceIds: instanceId ? [instanceId] : undefined }
+  );
+
+  const describeParams = {
+    InstanceIds: instanceId ? [instanceId] : undefined,
+  };
+  const describeCommand = new DescribeInstancesCommand(describeParams);
+  const response = await ec2Client.send(describeCommand);
+
+  if (
+    !response.Reservations ||
+    response.Reservations.length === 0 ||
+    !response.Reservations[0].Instances ||
+    response.Reservations[0].Instances.length === 0
+  ) {
+    console.error("No instance information found.");
+    return;
+  }
+
+  const instance = response.Reservations[0].Instances[0];
+  const rabbitUrl = `http://${instance.PublicDnsName}:15672/api/health/checks/port-listener/15672`;
+  const interval = 5000;
+  const timeout = 120000;
+  const startTime = Date.now();
+  let loggedNotReady = false;
+  while (Date.now() - startTime < timeout) {
+    try {
+      const response = await axios.get(rabbitUrl, {
+        auth: {
+          username,
+          password,
+        },
+      });
+      if (response.data && response.data.status === "ok") {
+        console.log("RabbitMQ is up; storing credentials in DynamoDB...");
+        // TOTO:
+        //   await storeCredentialsToDynamoDB({ instanceId, username, password });
+        return; // Stop polling once the server is up and credentials stored.
+      }
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        if (error.code === "ECONNREFUSED") {
+          if (!loggedNotReady) {
+            console.log("RabbitMQ not ready yet... ECONNREFUSED");
+            loggedNotReady = true;
+          }
+        } else {
+          console.log(
+            "RabbitMQ is up, waiting for credentials to be available..."
+          );
+        }
+      } else {
+        console.log("Unexpected error:", error);
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  console.log("Polling timed out; RabbitMQ server did not come up in time.");
+}


### PR DESCRIPTION
Added a health check function and optimized the instance set up script.
1. Did some testing. It takes around 70s from EC2 running to RabbitMQ management ui being available.
2. There is a short gap between ui being ready and user being registered. This is a known issue. (port will open to connection, but the user might not be ready just yet). My testing shows that there is around 5 seconds delay (might be shorter because my current interval is 5s, feels like making it too frequent is not need).
3. Also optimized the start up script so that it is no longer waiting for 20 seconds, instead, it also uses polling.
4. For testing the code, check the backend terminal output for information/status.